### PR TITLE
Grafana Dashboard Provisioning Fixes & Observability Improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,10 +40,13 @@ services:
     container_name: grafana
     ports:
       - "${GRAFANA_HOST_PORT}:3000"
-    volumes:
-      - grafana-storage:/var/lib/grafana
-    depends_on:
-      - prometheus
+    volumes:           # persists user data
+      - ./grafana/dashboards:/etc/grafana/dashboards # auto-load dashboards
+      - ./grafana/provisioning:/etc/grafana/provisioning # provisioning config
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
 
 volumes:
   grafana-storage:

--- a/grafana/dashboards/spanish-tutor-dashboard.json
+++ b/grafana/dashboards/spanish-tutor-dashboard.json
@@ -1,0 +1,24 @@
+{
+    "id": null,
+    "uid": "spanish-tutor",
+    "title": "Working Dashboard Test 6",
+    "schemaVersion": 36,
+    "version": 1,
+    "refresh": "10s",
+    "panels": [
+      {
+        "type": "stat",
+        "title": "Chat Turns per Minute",
+        "id": 1,
+        "datasource": "Prometheus",
+        "targets": [
+          {
+            "expr": "rate(chat_turns_total[1m])",
+            "format": "time_series"
+          }
+        ],
+        "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+        "fieldConfig": { "defaults": { "unit": "none" } }
+      }
+    ]
+  }

--- a/grafana/provisioning/dashboards/dashboards.yaml
+++ b/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/dashboards

--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,7 @@
+     apiVersion: 1
+     datasources:
+       - name: Prometheus
+         type: prometheus
+         access: proxy
+         url: http://prometheus:9090
+         isDefault: true

--- a/spanishtutor/src/api/app.py
+++ b/spanishtutor/src/api/app.py
@@ -1,9 +1,10 @@
+from prometheus_client import Histogram
 from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import List, Tuple
 
 from spanishtutor.src.core.tutor import SpanishTutor
-from spanishtutor.src.core.metrics import chat_turns_total
+from spanishtutor.src.core.metrics import chat_turns_total, chat_response_latency
 from prometheus_fastapi_instrumentator import Instrumentator
 
 app = FastAPI()
@@ -22,7 +23,10 @@ def health_check():
 @app.post("/chat")
 def chat(request: ChatRequest):
     chat_turns_total.inc()
-    response = ""
-    for chunk in tutor.generate_response(request.message, request.history):
-        response = chunk
+
+    with chat_response_latency.time(): # used as a context manager times everything inside the with block. 
+        response = ""
+        for chunk in tutor.generate_response(request.message, request.history):
+            response = chunk
+
     return {"reply": response}

--- a/spanishtutor/src/core/metrics.py
+++ b/spanishtutor/src/core/metrics.py
@@ -1,12 +1,50 @@
 # spanishtutor/src/metrics.py
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram, Gauge, Summary, Info
+import time
 
 # These variables live in memory and can be used from any part of the app by importing them. 
 # Prometheus scrapes the current values at each interval.
 # NOTE: If metrics were defined inside the route handler, it would get re-created every time the route is called, 
-# and Prometheus wouldn’t see an incrementing number.
+# and Prometheus wouldn't see an incrementing number.
 # s.py, it's created once and stays in memory for the life of the app — so Prometheus can keep scraping and accumulating the correct values.
+
+# === Core Chat Metrics ===
 chat_turns_total = Counter(
     "chat_turns_total",
     "Total number of chat turns processed"
+)
+
+chat_requests_total = Counter(
+    "chat_requests_total", 
+    "Total number of chat requests received"
+)
+
+chat_response_latency = Histogram(
+    "chat_response_latency_seconds", 
+    "Time taken to respond to a chat request"
+)
+
+chat_chunks_total = Counter(
+    "chat_chunks_total", 
+    "Total number of LLM streaming chunks sent"
+)
+
+# === Error Metrics ===
+llm_error_count = Counter(
+    "llm_error_count", 
+    "Total number of LLM errors", 
+    ["error_type"]
+)
+
+# === User Behavior Metrics ===
+user_level_gauge = Gauge(
+    "active_user_level", 
+    "Gauge for user level", 
+    ["level"]
+)
+
+# === Application Info ===
+app_info = Info(
+    "spanishtutor_app", 
+    "Info about the Spanish Tutor app"
 )


### PR DESCRIPTION
See [Ticket](https://github.com/camilleC/SpanishTutor/issues/6)

## tldr
Dashboards now auto-provision correctly on Grafana startup
No manual dashboard import required
Improved observability and monitoring setup for the Spanish Tutor application

## Testing
Restarted Grafana and verified that dashboards appear at http://localhost:3000/dashboards
Confirmed no provisioning errors in Grafana logs


# Summary of changes
1. Grafana Dashboard Provisioning Structure
Moved provisioning files (dashboards.yaml, datasources.yaml) into their correct subdirectories:
Now located at grafana/provisioning/dashboards/dashboards.yaml and grafana/provisioning/datasources/datasources.yaml
Ensured Docker Compose mounts for grafana/dashboards and grafana/provisioning are correct

2. Dashboard JSON Format Correction
Fixed dashboard JSON structure:
Removed the outer { "dashboard": ..., "overwrite": true } wrapper from spanish-tutor-dashboard.json
Now the "title" and other dashboard fields are at the root level, as required by Grafana provisioning

3. Data Source Provisioning
Added/verified Prometheus data source in datasources.yaml to ensure dashboards can query metrics

4. Troubleshooting & Validation
Checked file permissions to ensure Grafana can read all dashboard and provisioning files
Analyzed Grafana logs to identify and resolve the "Dashboard title cannot be empty" error
Validated directory structure and file placement for successful dashboard auto-loading

5. Documentation & Consistency
Standardized YAML file extensions for clarity and consistency
Documented correct directory structure and provisioning requirements
